### PR TITLE
Allow columns that map to json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=7.1"
+    "php": ">=7.1",
+    "zumba/json-serializer": "^2.2"
   },
   "require-dev": {
     "phpunit/dbunit": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ce4ca53bc0500a73be0d73c27dec961",
-    "packages": [],
+    "content-hash": "e50f7613ef44102abc78e98b15562847",
+    "packages": [
+        {
+            "name": "zumba/json-serializer",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zumba/json-serializer.git",
+                "reference": "b7415a88841f4493eddfba390456b25fe22e286a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zumba/json-serializer/zipball/b7415a88841f4493eddfba390456b25fe22e286a",
+                "reference": "b7415a88841f4493eddfba390456b25fe22e286a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.*"
+            },
+            "suggest": {
+                "jeremeamia/superclosure": "Allow to serialize PHP closures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Zumba\\": "src/",
+                    "Zumba\\JsonSerializer\\Test\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Juan Basso",
+                    "email": "juan.basso@zumba.com"
+                },
+                {
+                    "name": "Zumba Fitness, LLC",
+                    "email": "engineering@zumba.com"
+                }
+            ],
+            "description": "Serialize PHP variables, including objects, in JSON format. Support to unserialize it too.",
+            "homepage": "http://tech.zumba.com",
+            "keywords": [
+                "json",
+                "serialize",
+                "serializer"
+            ],
+            "time": "2018-02-07T18:14:13+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codacy/coverage",
@@ -13,12 +68,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/codacy/php-codacy-coverage.git",
-                "reference": "4988cd098db4d578681bfd3176071931ad475150"
+                "reference": "629d1fd597f91fb072bd822830059fd5145ce49a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codacy/php-codacy-coverage/zipball/4988cd098db4d578681bfd3176071931ad475150",
-                "reference": "4988cd098db4d578681bfd3176071931ad475150",
+                "url": "https://api.github.com/repos/codacy/php-codacy-coverage/zipball/629d1fd597f91fb072bd822830059fd5145ce49a",
+                "reference": "629d1fd597f91fb072bd822830059fd5145ce49a",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +105,7 @@
             ],
             "description": "Sends PHP test coverage information to Codacy.",
             "homepage": "https://github.com/codacy/php-codacy-coverage",
-            "time": "2018-03-22T16:43:39+00:00"
+            "time": "2018-04-30T16:23:12+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/src/Entity/PersistentAttribute.php
+++ b/src/Entity/PersistentAttribute.php
@@ -65,6 +65,7 @@ class PersistentAttribute {
 			$this->type = $definition[0];
 			if ($this->type == T::JSON) {
 				$this->type = T::Text;
+				$this->extra = '';
 			}
 			$this->default = null;
 			if (isset($definition[1]) AND $definition[1]) {

--- a/src/Entity/PersistentAttribute.php
+++ b/src/Entity/PersistentAttribute.php
@@ -63,10 +63,6 @@ class PersistentAttribute {
 
 		if ($definition != null) {
 			$this->type = $definition[0];
-			if ($this->type == T::JSON) {
-				$this->type = T::Text;
-				$this->extra = '';
-			}
 			$this->default = null;
 			if (isset($definition[1]) AND $definition[1]) {
 				$this->null = 'YES';
@@ -74,6 +70,10 @@ class PersistentAttribute {
 				$this->null = 'NO';
 			}
 			$this->extra = (isset($definition[2]) ? $definition[2] : '');
+			if ($this->type == T::JSON) {
+				$this->type = T::Text;
+				$this->extra = '';
+			}
 			if ($this->type === T::Enumeration) {
 				$class = $this->extra;
 				$this->type = "enum('" . implode("','", $class::getTypeOptions()) . "')";

--- a/src/Entity/PersistentAttribute.php
+++ b/src/Entity/PersistentAttribute.php
@@ -63,6 +63,9 @@ class PersistentAttribute {
 
 		if ($definition != null) {
 			$this->type = $definition[0];
+			if ($this->type == T::JSON) {
+				$this->type = T::Text;
+			}
 			$this->default = null;
 			if (isset($definition[1]) AND $definition[1]) {
 				$this->null = 'YES';

--- a/src/Entity/PersistentEntity.php
+++ b/src/Entity/PersistentEntity.php
@@ -177,6 +177,10 @@ abstract class PersistentEntity implements \JsonSerializable {
 		}
 		foreach ($attributes as $attribute) {
 			$values[$attribute] = pdo_bool($this->$attribute);
+			if ($this->getAttributeDefinition($attribute)[0]==T::JSON) {
+				$serializer = new \Zumba\JsonSerializer\JsonSerializer();
+				$values[$attribute] = $serializer->serialize($this->$attribute);
+			}
 		}
 		if ($primary_key_only) {
 			return array_values($values);
@@ -202,7 +206,10 @@ abstract class PersistentEntity implements \JsonSerializable {
 				$this->$attribute = (int)$this->$attribute;
 			} elseif ($definition[0] === T::Float) {
 				$this->$attribute = (float)$this->$attribute;
-			} else {
+			} elseif ($definition[0] === T::JSON) {
+				$serializer = new \Zumba\JsonSerializer\JsonSerializer();
+				$this->$attribute = $serializer->unserialize($this->$attribute);
+			}else {
 				$this->$attribute = (string)$this->$attribute;
 			}
 			// If $definition comes from PersistentAttribute->toDefinition, $definition[2] is an array if the definition is an enum

--- a/src/Entity/PersistentEntity.php
+++ b/src/Entity/PersistentEntity.php
@@ -2,6 +2,7 @@
 namespace CsrDelft\Orm\Entity;
 
 use function common\pdo_bool;
+use CsrDelft\Orm\JsonSerializer\SafeJsonSerializer;
 use Exception;
 
 /**
@@ -177,8 +178,9 @@ abstract class PersistentEntity implements \JsonSerializable {
 		}
 		foreach ($attributes as $attribute) {
 			$values[$attribute] = pdo_bool($this->$attribute);
-			if ($this->getAttributeDefinition($attribute)[0]==T::JSON) {
-				$serializer = new \Zumba\JsonSerializer\JsonSerializer();
+			$attributeDef = $this->getAttributeDefinition($attribute);
+			if ($attributeDef[0]==T::JSON) {
+				$serializer = new SafeJsonSerializer($attributeDef[2]);
 				$values[$attribute] = $serializer->serialize($this->$attribute);
 			}
 		}
@@ -207,7 +209,7 @@ abstract class PersistentEntity implements \JsonSerializable {
 			} elseif ($definition[0] === T::Float) {
 				$this->$attribute = (float)$this->$attribute;
 			} elseif ($definition[0] === T::JSON) {
-				$serializer = new \Zumba\JsonSerializer\JsonSerializer();
+				$serializer = new SafeJsonSerializer($definition[2]);
 				$this->$attribute = $serializer->unserialize($this->$attribute);
 			}else {
 				$this->$attribute = (string)$this->$attribute;

--- a/src/Entity/T.php
+++ b/src/Entity/T.php
@@ -22,6 +22,7 @@ abstract class T extends PersistentEnum {
 	const LongText = 'longtext';
 	const Enumeration = 'enum';
 	const UID = 'varchar(4)';
+	const JSON = 'json';
 
 	protected static $supportedChoices = [
 		self::String => self::String,
@@ -37,6 +38,7 @@ abstract class T extends PersistentEnum {
 		self::LongText => self::LongText,
 		self::Enumeration => self::Enumeration,
 		self::UID => self::UID,
+		self::JSON => self::JSON
 	];
 
 	/**
@@ -56,6 +58,7 @@ abstract class T extends PersistentEnum {
 		self::LongText => 'Tekst (lang)',
 		self::Enumeration => 'Voorgedefinieerde waarden',
 		self::UID => 'Lidnummer',
+		self::JSON => 'JSON'
 	];
 
 	/**
@@ -75,5 +78,6 @@ abstract class T extends PersistentEnum {
 		self::LongText => 'lt',
 		self::Enumeration => 'e',
 		self::UID => 'u',
+		self::JSON => 'j'
 	];
 }

--- a/src/JsonSerializer/SafeJsonSerializer.php
+++ b/src/JsonSerializer/SafeJsonSerializer.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: sander
+ * Date: 13-7-18
+ * Time: 11:08
+ */
+
+namespace CsrDelft\Orm\JsonSerializer;
+
+use ReflectionClass;
+use Zumba\JsonSerializer\Exception\JsonSerializerException;
+
+/**
+ * JsonSerializer that only allows serializing and deserializing of classes that are explicitly allowed.
+ * @package CsrDelft\Orm\JsonSerializer
+ */
+class SafeJsonSerializer extends \Zumba\JsonSerializer\JsonSerializer {
+
+	/**
+	 * Array of allowed classes
+	 * @var string[]
+	 */
+	protected $allowedClasses;
+
+	/**
+	 * SafeJsonSerializer constructor.
+	 * @param string[] $allowedClasses The classnames of classes that this serializer is allowed to (de)serialize. Passing null will allow all classes.
+	 * @param array $customObjectSerializerMap
+	 */
+	public function __construct(array $allowedClasses = null, array $customObjectSerializerMap = array()) {
+		parent::__construct(null, $customObjectSerializerMap);
+		$this->allowedClasses = (array)$allowedClasses;
+	}
+
+	/**
+	 * @param object $value
+	 * @return array
+	 * @throws \ReflectionException
+	 */
+	protected function serializeObject($value) {
+		$ref = new ReflectionClass($value);
+		$className = $ref->getName();
+		if ($this->classAllowed($className)) {
+			return parent::serializeObject($value);
+		} else {
+			throw new SafeJsonSerializerException("Serializing of $className is not allowed by this SafeJsonSerializer");
+		}
+	}
+
+	protected function unserializeObject($value) {
+		$className = $value[static::CLASS_IDENTIFIER_KEY];
+		if ($this->classAllowed($className)) {
+			return parent::unserializeObject($value);
+		} else {
+			throw new SafeJsonSerializerException("Deserializing of $className is not allowed by this SafeJsonSerializer");
+		}
+	}
+
+	/**
+	 * Whether this classname is allowed to be (un)serialized.
+	 * @param $className
+	 */
+	protected function classAllowed($className) {
+		return $this->allowedClasses === null || in_array($className, $this->allowedClasses);
+	}
+
+}

--- a/src/JsonSerializer/SafeJsonSerializerException.php
+++ b/src/JsonSerializer/SafeJsonSerializerException.php
@@ -13,5 +13,6 @@ class SafeJsonSerializerException extends JsonSerializerException {
 	 * @param string $string
 	 */
 	public function __construct($string) {
+		parent::__construct($string);
 	}
 }

--- a/src/JsonSerializer/SafeJsonSerializerException.php
+++ b/src/JsonSerializer/SafeJsonSerializerException.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace CsrDelft\Orm\JsonSerializer;
+
+
+use Zumba\JsonSerializer\Exception\JsonSerializerException;
+
+class SafeJsonSerializerException extends JsonSerializerException {
+
+	/**
+	 * SafeJsonSerializerException constructor.
+	 * @param string $string
+	 */
+	public function __construct($string) {
+	}
+}

--- a/tests/JsonSerializer/JsonSerializerTest.php
+++ b/tests/JsonSerializer/JsonSerializerTest.php
@@ -1,0 +1,65 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class Allowed {
+	public $var;
+}
+
+class NotAllowed {
+	public $var;
+}
+
+class JsonSerializerTest extends TestCase  {
+
+	public function testInt() {
+		$serializer = new \CsrDelft\Orm\JsonSerializer\SafeJsonSerializer([Allowed::class]);
+		$obj = new Allowed();
+		$obj->var = 1;
+		$serializer->unserialize($serializer->serialize($obj));
+		$this->addToAssertionCount(1);
+	}
+
+	public function testArray() {
+		$serializer = new \CsrDelft\Orm\JsonSerializer\SafeJsonSerializer([Allowed::class]);
+		$obj = new Allowed();
+		$obj->var = [0,1,2];
+		$serializer->unserialize($serializer->serialize($obj));
+		$this->addToAssertionCount(1);
+	}
+
+	public function testString() {
+		$serializer = new \CsrDelft\Orm\JsonSerializer\SafeJsonSerializer([Allowed::class]);
+		$obj = new Allowed();
+		$obj->var = [0,1,2];
+		$serializer->unserialize($serializer->serialize($obj));
+		$this->addToAssertionCount(1);
+	}
+
+	public function testMap() {
+		$serializer = new \CsrDelft\Orm\JsonSerializer\SafeJsonSerializer([Allowed::class]);
+		$obj = new Allowed();
+		$obj->var = ["key"=>"value"];
+		$serializer->unserialize($serializer->serialize($obj));
+		$this->addToAssertionCount(1);
+	}
+
+
+	/**
+	 * @expectedException \CsrDelft\Orm\JsonSerializer\SafeJsonSerializerException
+	 */
+	public function testSerializeNotAllowed() {
+		$serializer = new \CsrDelft\Orm\JsonSerializer\SafeJsonSerializer([Allowed::class]);
+		$obj = new Allowed();
+		$obj->var = [new NotAllowed()];
+		$serializer->serialize($obj);
+	}
+
+	/**
+	 * @expectedException \CsrDelft\Orm\JsonSerializer\SafeJsonSerializerException
+	 */
+	public function testDeserializeNotAllowed() {
+		$serializer = new \CsrDelft\Orm\JsonSerializer\SafeJsonSerializer([Allowed::class]);
+		$str = '{"@type":"Allowed","var":[{"@type":"NotAllowed","var":null}]}';
+		$serializer->unserialize($str);
+	}
+}

--- a/tests/Persistence/MySqlDatabaseTestCase.php
+++ b/tests/Persistence/MySqlDatabaseTestCase.php
@@ -23,7 +23,7 @@ abstract class MySqlDatabaseTestCase extends TestCase {
 					'cache_path' => '.',
 					'db' => [
 						'host' => '127.0.0.1',
-						'user' => 'travis',
+						'user' => 'root',
 						'db' => 'orm_test',
 						'pass' => ''
 					]
@@ -53,6 +53,8 @@ abstract class MySqlDatabaseTestCase extends TestCase {
 			foreach ($meta->getColumns() as $col) {
 				if ($col == 'id') {
 					$cols[] = "`$col` INT NOT NULL auto_increment";
+				} else if ($col === 'json'){
+					$cols[] = "`$col` TEXT";
 				} else {
 					$cols[] = "`$col` VARCHAR(200)";
 				}

--- a/tests/PersistenceModelIntegrationTest.php
+++ b/tests/PersistenceModelIntegrationTest.php
@@ -9,7 +9,7 @@ class Car extends PersistentEntity {
 	public $id;
 	public $num_wheels;
 	public $brand;
-
+	public $json;
 	protected static $persistent_attributes = [
 		'id' => [T::Integer, false, 'auto_increment'],
 		'num_wheels' => [T::Integer],

--- a/tests/PersistenceModelIntegrationTest.php
+++ b/tests/PersistenceModelIntegrationTest.php
@@ -13,7 +13,8 @@ class Car extends PersistentEntity {
 	protected static $persistent_attributes = [
 		'id' => [T::Integer, false, 'auto_increment'],
 		'num_wheels' => [T::Integer],
-		'brand' => [T::String]
+		'brand' => [T::String],
+		'json' => [T::JSON]
 	];
 	protected static $table_name = 'car';
 	protected static $primary_key = ['id'];
@@ -23,6 +24,9 @@ class CarModel extends PersistenceModel {
 	const ORM = Car::class;
 }
 
+class TestClass {
+	public $info;
+}
 /**
  * PersistenceModelTest.php
  *
@@ -62,10 +66,21 @@ final class PersistenceModelIntegrationTest extends MySqlDatabaseTestCase {
 		$car = new Car();
 		$car->num_wheels = 2;
 		$car->brand = "Yamaha";
-
 		$this->model->create($car);
 
 		$this->assertEquals(3, $this->model->count());
+	}
+
+	public function testJson() {
+		$car = new Car();
+		$car->json = new TestClass();
+		$car->json->info = "test";
+
+		$samecar = new Car();
+		$samecar->id = $this->model->create($car);
+		$this->model->retrieve($samecar);
+
+		$this->assertEquals($samecar->json->info, "test");
 	}
 
 	public function testRetrieve() {

--- a/tests/PersistenceModelIntegrationTest.php
+++ b/tests/PersistenceModelIntegrationTest.php
@@ -14,7 +14,7 @@ class Car extends PersistentEntity {
 		'id' => [T::Integer, false, 'auto_increment'],
 		'num_wheels' => [T::Integer],
 		'brand' => [T::String],
-		'json' => [T::JSON]
+		'json' => [T::JSON, true, [TestClass::class]]
 	];
 	protected static $table_name = 'car';
 	protected static $primary_key = ['id'];

--- a/tests/integrationDataset.xml
+++ b/tests/integrationDataset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <dataset>
-    <car id="1" num_wheels="4" brand="Opel"/>
-    <car id="2" num_wheels="3" brand="Delorean"/>
+    <car id="1" num_wheels="4" brand="Opel" json="[]" />
+    <car id="2" num_wheels="3" brand="Delorean" json="[]" />
 </dataset>


### PR DESCRIPTION
Adds an extra column type T::JSON. Objects in JSON fields are automatically serialized using zumba/json-serializer when writing them to the database. Functionality is needed for https://github.com/csrdelft/csrdelft.nl/pull/425.